### PR TITLE
fix exception when response lacks content-type

### DIFF
--- a/siesta/__init__.py
+++ b/siesta/__init__.py
@@ -220,8 +220,8 @@ class Resource(object):
             resource = Resource(uri=urlparse(location).path, api=self.api).get()
             return resource
         #logging.info("resp.getheader(): %s" % resp.getheader('content-type'))
-        m = re.match('^([^;]*)(?:;\s*charset=(.*))?$',
-                     resp.getheader('content-type'))
+        type = resp.getheader('content-type', '')
+        m = re.match('^([^;]*)(?:;\s*charset=(.*))?$', type)
         #logging.info("response: %s" % resp)
         
         if m == None:


### PR DESCRIPTION
not all APIs respond with a content-type header
specifically actions such as DELETE may not have a body